### PR TITLE
env expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The sidekick supports the following resource types: mysql, postgres, pki, aws, s
 **Environment Variable Expansion**
 
 The resource paths can contain environment variables which the sidekick will resolve beforehand. A use case being, using a environment
-or domain within the resource e.g -cn=secret:secrets/myservice/%ENV%/config:fmt=yaml
+or domain within the resource e.g -cn=secret:secrets/myservice/${ENV}/config:fmt=yaml
 
 **Output Formatting**
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	Prog    = "vault-sidekick"
-	Version = "v0.1.2"
+	Version = "v0.2.0"
 )
 
 func main() {

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -25,10 +25,6 @@ import (
 	"time"
 )
 
-var (
-	envRegex = regexp.MustCompile("%[[:alnum:]_]+%")
-)
-
 // VaultResources is a collection of type resource
 type VaultResources struct {
 	// an array of resource to retrieve
@@ -41,7 +37,7 @@ func (r *VaultResources) Set(value string) error {
 	rn := defaultVaultResource()
 
 	// step: split on the ':'
-	items := strings.Split(value, ":")
+	items := strings.Split(os.ExpandEnv(value), ":")
 	if len(items) < 2 {
 		return fmt.Errorf("invalid resource, must have at least two sections TYPE:PATH")
 	}
@@ -50,15 +46,6 @@ func (r *VaultResources) Set(value string) error {
 	}
 	if items[0] == "" || items[1] == "" {
 		return fmt.Errorf("invalid resource, neither type or path can be empty")
-	}
-
-	// step: look for any token in the resource
-	tokens := envRegex.FindAllStringSubmatch(items[1], -1)
-	if len(tokens) > 0 {
-		for _, x := range tokens {
-			// step: replace the token with the environment variable
-			items[1] = strings.Replace(items[1], x[0], os.Getenv(strings.Replace(x[0], "%", "", -1)), -1)
-		}
 	}
 
 	// step: extract the elements

--- a/vault_resources_test.go
+++ b/vault_resources_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"fmt"
 )
 
 func TestSetResources(t *testing.T) {
@@ -34,7 +35,7 @@ func TestSetResources(t *testing.T) {
 	assert.Nil(t, items.Set("pki:example-dot-com:common_name=blah.example.com"))
 	assert.Nil(t, items.Set("pki:example-dot-com:common_name=blah.example.com,file=/etc/certs/ssl/blah.example.com"))
 	assert.Nil(t, items.Set("pki:example-dot-com:common_name=blah.example.com,renew=true"))
-	assert.Nil(t, items.Set("secret:secrets/%ENV%/me:file=filename.test,fmt=yaml"))
+	assert.Nil(t, items.Set("secret:secrets/${ENV}/me:file=filename.test,fmt=yaml"))
 
 
 	assert.NotNil(t, items.Set("secret:"))
@@ -51,25 +52,25 @@ func TestSetEnvironmentResource(t *testing.T) {
 		Vars         map[string]string
 	}{
 		{
-			ResourceText: "secret:secrets/%ENV/me:file=filename.test,fmt=yaml",
-			ExpectedPath: "secrets/%ENV/me",
+			ResourceText: "secret:secrets/${ENV}/me:file=filename.test,fmt=yaml",
+			ExpectedPath: "secrets//me",
 		},
 		{
-			ResourceText: "secret:secrets/%ENV%/me:file=filename.test,fmt=yaml",
+			ResourceText: "secret:secrets/${ENV}/me:file=filename.test,fmt=yaml",
 			ExpectedPath: "secrets/dev/me",
 			Vars: map[string]string{
 				"ENV": "dev",
 			},
 		},
 		{
-			ResourceText: "secret:secrets/%ENV%/me/%ENV%:file=filename.test,fmt=yaml",
+			ResourceText: "secret:secrets/${ENV}/me/${ENV}:file=filename.test,fmt=yaml",
 			ExpectedPath: "secrets/dev/me/dev",
 			Vars: map[string]string{
 				"ENV": "dev",
 			},
 		},
 		{
-			ResourceText: "secret:secrets/%ENV%/me/%THING%:file=filename.test,fmt=yaml",
+			ResourceText: "secret:secrets/${ENV}/me/${THING}:file=filename.test,fmt=yaml",
 			ExpectedPath: "secrets/dev/me/yes",
 			Vars: map[string]string{
 				"ENV":   "dev",
@@ -77,7 +78,7 @@ func TestSetEnvironmentResource(t *testing.T) {
 			},
 		},
 		{
-			ResourceText: "secret:secrets/%KUBERNETES_NAMESPACE%/me:file=filename.test,fmt=yaml",
+			ResourceText: "secret:secrets/${KUBERNETES_NAMESPACE}/me:file=filename.test,fmt=yaml,common_name=${KUBERNETES_NAMESPACE}.test",
 			ExpectedPath: "secrets/dev/me",
 			Vars: map[string]string{
 				"KUBERNETES_NAMESPACE":   "dev",


### PR DESCRIPTION
- switching to using the os.ExpandEnv methods rather than tokenizing the string
- updated the readme to reflect the changes