### PR TITLE
enable env vars for auth settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The above say's
 A authentication file can be specified in either yaml of json format which contains a method field, indicating one of the authentication
 methods provided by vault i.e. userpass, token, github etc and then followed by the required arguments for that plugin.
 
+If the required arguments for that plugin are not contained in the authentication file, fallbacks from environment variables are used.
+Environment variables are prefixed with `VAULT_SIDEKICK`, i.e. `VAULT_SIDEKICK_USERNAME`, `VAULT_SIDEKICK_PASSWORD`.
+
 **Secret Renewals**
 
 The default behaviour of vault-sidekick is **not** to renew a lease, but to retrieve a new secret and allow the previous to

--- a/auth_userpass.go
+++ b/auth_userpass.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/vault/api"
 )
@@ -44,6 +45,13 @@ func (r authUserPassPlugin) Create(cfg map[string]string) (string, error) {
 	// step: extract the options
 	username, _ := cfg["username"]
 	password, _ := cfg["password"]
+
+	if username == "" {
+		username = os.Getenv("VAULT_SIDEKICK_USERNAME")
+	}
+	if password == "" {
+		password = os.Getenv("VAULT_SIDEKICK_PASSWORD")
+	}
 
 	// step: create the token request
 	request := r.client.NewRequest("POST", fmt.Sprintf("/v1/auth/userpass/login/%s", username))


### PR DESCRIPTION
This change enables the use of environment variables for auth settings, i.e. for the userpass backend. The existing behavior is preserved where the authentication file is checked first, and only if the values are missing or empty will environment variables be checked. Variables are nested under `VAULT_SIDEKICK`, i.e. `VAULT_SIDEKICK_USERNAME`, `VAULT_SIDEKICK_PASSWORD`. 

This method of passing credentials should be much easier to integrate with kubernetes secrets.