### PR TITLE
enable authentication with approle backend

### DIFF
--- a/auth_approle.go
+++ b/auth_approle.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2015 Home Office All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// the userpass authentication plugin
+type authAppRolePlugin struct {
+	client *api.Client
+}
+
+type appRoleLogin struct {
+	RoleId   string `json:"role_id,omitempty"`
+	SecretId string `json:"secret_id,omitempty"`
+}
+
+// NewAppRolePlugin creates a new App Role plugin
+func NewAppRolePlugin(client *api.Client) AuthInterface {
+	return &authAppRolePlugin{
+		client: client,
+	}
+}
+
+// Create a approle plugin with the secret id and role id provided in the file
+func (r authAppRolePlugin) Create(cfg map[string]string) (string, error) {
+	// step: extract the options
+	roleId, _ := cfg["role_id"]
+	secretId, _ := cfg["secret_id"]
+
+	if roleId == "" {
+		roleId = os.Getenv("VAULT_SIDEKICK_ROLE_ID")
+	}
+	if secretId == "" {
+		secretId = os.Getenv("VAULT_SIDEKICK_SECRET_ID")
+	}
+
+	// step: create the token request
+	request := r.client.NewRequest("POST", "/v1/auth/approle/login")
+	login := appRoleLogin{SecretId: secretId, RoleId: roleId}
+	if err := request.SetJSONBody(login); err != nil {
+		return "", err
+	}
+	// step: make the request
+	resp, err := r.client.RawRequest(request)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// step: parse and return auth
+	secret, err := api.ParseSecret(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return secret.Auth.ClientToken, nil
+}

--- a/vault.go
+++ b/vault.go
@@ -25,9 +25,10 @@ import (
 	"net/http"
 	"time"
 
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/hashicorp/vault/api"
-	"strings"
 )
 
 const (
@@ -428,6 +429,8 @@ func newVaultClient(opts *config) (*api.Client, error) {
 	switch plugin {
 	case "userpass":
 		token, err = NewUserPassPlugin(client).Create(opts.vaultAuthOptions)
+	case "approle":
+		token, err = NewAppRolePlugin(client).Create(opts.vaultAuthOptions)
 	case "token":
 		opts.vaultAuthOptions["filename"] = options.vaultAuthFile
 		token, err = NewUserTokenPlugin(client).Create(opts.vaultAuthOptions)


### PR DESCRIPTION
This enables authenticating with the vault approle backend, using a `secret_id` and `role_id`. It uses the existing method of passing variables in the auth file, and in the spirit of #25 allows falling back to env vars.

Didn't combine this with the existing auth logic by path because the login paths used by userpass and app role are unique (userpass expects username in path) and accept different payloads.