### PR TITLE
added vault user instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,10 @@ RUN apk update && \
 
 ADD bin/vault-sidekick /vault-sidekick
 
+RUN adduser -D vault && \
+    chown -R vault:vault /vault-sidekick && \
+    mkdir /etc/secrets && \
+    chown -R vault:vault /etc/secrets
+
 ENTRYPOINT [ "/vault-sidekick" ]
+USER vault


### PR DESCRIPTION
continuing my crusade of getting rid of root user in our containers, I believe this should work as long as people don't mount their secrets in a weird place that isn't /etc/secrets