### PR TITLE
Add 'retries' parameter to resources to allow optional maxRetries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spec:
           - -output=/etc/secrets
           - -cn=pki:project1/certs/example.com:common_name=commons.example.com,revoke=true,update=2h
           - -cn=secret:secret/db/prod/username:file=.credentials
-          - -cn=secret:secret/db/prod/password
+          - -cn=secret:secret/db/prod/password:retries=true
           - -cn=aws:aws/creds/s3_backup_policy:file=.s3_creds
         volumeMounts:
           - name: secrets
@@ -146,3 +146,4 @@ bundle format is very similar in the sense it similar takes the private key and 
 - **revoke**: (revoke) revoke the old lease when you get retrieve a old one e.g. true, TRUE (default to allow the lease to expire and naturally revoke)
 - **fmt**: (format) allows you to specify the output format of the resource / secret, e.g json, yaml, ini, txt
 - **exec** (execute) execute's a command when resource is updated or changed
+- **retries**: (retries) the maximum number of times to retry retrieving a resource. If not set, resources will be retried indefinitely

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -46,6 +46,8 @@ const (
 	optionSize = "size"
 	// optionsMode is the file permissions on the secret
 	optionMode = "mode"
+	// optionMaxRetries is the maximum number of retries that should be attempted
+	optionMaxRetries = "retries"
 	// defaultSize sets the default size of a generic secret
 	defaultSize = 20
 )
@@ -109,6 +111,12 @@ type VaultResource struct {
 	options map[string]string
 	// the file permissions on the resource
 	fileMode os.FileMode
+	// maxRetries is the maximum number of times this resource should be
+	// attempted to be retrieved from Vault before failing
+	maxRetries int
+	// retries is the number of times this resource has been retried since it
+	// last succeeded
+	retries int
 }
 
 // GetFilename generates a resource filename by default the resource name and resource type, which
@@ -158,5 +166,9 @@ func (r *VaultResource) isValidResource() error {
 
 // String returns a string representation of the struct
 func (r VaultResource) String() string {
-	return fmt.Sprintf("type: %s, path:%s", r.resource, r.path)
+	str := fmt.Sprintf("type: %s, path: %s", r.resource, r.path)
+	if r.maxRetries > 0 {
+		str = fmt.Sprintf("%s, attempts: %d/%d", str, r.retries, r.maxRetries+1)
+	}
+	return str
 }

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -131,6 +131,12 @@ func (r *VaultResources) Set(value string) error {
 				rn.filename = value
 			case optionTemplatePath:
 				rn.templateFile = value
+			case optionMaxRetries:
+				maxRetries, err := strconv.ParseInt(value, 10, 32)
+				if err != nil {
+					return fmt.Errorf("the retries option: %s is invalid, should be an integer", value)
+				}
+				rn.maxRetries = int(maxRetries)
 			default:
 				rn.options[name] = value
 			}


### PR DESCRIPTION
This PR adds an optional 'retries' parameter to VaultResource. If it is not set, it should behave as now.

It behaves well with the recently added one-shot mode. The current 'modes' are:

* `retries` set and one-shot=true: will retry up to N times and then exit with a failure code if it's unsuccessful
* `retries` not set and one-shot=true: will retry indefinitely (as it does now)
* `retries` set and one-shot=false: will retry up to N times, and then stop attempting to process the event. If all items in the processing loop have reached maxRetries, vault-sidekick exits with code 1
* `retries` not set and one-shot=false: will retry indefinitely (as it does now) 

Closes #10 
