### PR TITLE
Add support for optional jitter parameter on CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,4 @@ bundle format is very similar in the sense it similar takes the private key and 
 - **fmt**: (format) allows you to specify the output format of the resource / secret, e.g json, yaml, ini, txt
 - **exec** (execute) execute's a command when resource is updated or changed
 - **retries**: (retries) the maximum number of times to retry retrieving a resource. If not set, resources will be retried indefinitely
+* **jitter**: (jitter) an optional maximum jitter duration. If specified, a random duration between 0 and `jitter` will be subtracted from the renewal time for the resource

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -48,6 +48,10 @@ const (
 	optionMode = "mode"
 	// optionMaxRetries is the maximum number of retries that should be attempted
 	optionMaxRetries = "retries"
+	// optionMaxJitter is the maximum amount of jitter that should be applied
+	// to updates for this resource. If non-zero, a random value between 0 and
+	// maxJitter will be subtracted from the update period.
+	optionMaxJitter = "jitter"
 	// defaultSize sets the default size of a generic secret
 	defaultSize = 20
 )
@@ -117,6 +121,9 @@ type VaultResource struct {
 	// retries is the number of times this resource has been retried since it
 	// last succeeded
 	retries int
+	// maxJitter is the maximum jitter duration to use for this resource when
+	// performing renewals
+	maxJitter time.Duration
 }
 
 // GetFilename generates a resource filename by default the resource name and resource type, which

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -137,6 +137,12 @@ func (r *VaultResources) Set(value string) error {
 					return fmt.Errorf("the retries option: %s is invalid, should be an integer", value)
 				}
 				rn.maxRetries = int(maxRetries)
+			case optionMaxJitter:
+				maxJitter, err := time.ParseDuration(value)
+				if err != nil {
+					return fmt.Errorf("the jitter option: %s is invalid, should be in duration format", value)
+				}
+				rn.maxJitter = maxJitter
 			default:
 				rn.options[name] = value
 			}

--- a/watched_resource.go
+++ b/watched_resource.go
@@ -57,6 +57,13 @@ func (r *watchedResource) notifyOnRenewal(ch chan *watchedResource) {
 			}
 			r.renewalTime = r.calculateRenewal()
 		}
+		if r.resource.maxJitter != 0 {
+			glog.V(4).Infof("using maxJitter (%s) to calculate renewal time", r.resource.maxJitter)
+			r.renewalTime = time.Duration(getDurationWithin(
+				int((r.renewalTime-r.resource.maxJitter)/time.Second),
+				int(r.renewalTime/time.Second),
+			))
+		}
 		glog.V(3).Infof("setting a renewal notification on resource: %s, time: %s", r.resource, r.renewalTime)
 		// step: wait for the duration
 		<-time.After(r.renewalTime)


### PR DESCRIPTION
Currently there's no way (aside from randomising before calling vault-sidekick) to generate *slightly* random times to renew/update resources.

This PR adds a `jitter` field to CNs. If specified, a duration up to `jitter` will be subtracted from the renewal time for the resource. This is useful if you are running many replicas of the same application, with the same configuration, and do not want them reloading credentials/secrets simultaneously.

/cc @gambol99 

Closes #50 
