### PR TITLE
auth: allow setting auth method via env var

### DIFF
--- a/config.go
+++ b/config.go
@@ -75,8 +75,9 @@ var (
 func init() {
 	// step: setup some defaults
 	options.resources = new(VaultResources)
+	authMethod := getEnv("VAULT_AUTH_METHOD", "token")
 	options.vaultAuthOptions = &vaultAuthOptions{
-		Method: "token",
+		Method: authMethod,
 	}
 
 	flag.StringVar(&options.vaultURL, "vault", getEnv("VAULT_ADDR", "https://127.0.0.1:8200"), "url the vault service or VAULT_ADDR")


### PR DESCRIPTION
Simply defaults to the value of env var `VAULT_AUTH_METHOD` instead of hard coding "token". Falls back to "token" if the env var is not set.