### PR TITLE
allow overriding separator string

### DIFF
--- a/vault_resources.go
+++ b/vault_resources.go
@@ -36,8 +36,9 @@ type VaultResources struct {
 func (r *VaultResources) Set(value string) error {
 	rn := defaultVaultResource()
 
-	// step: split on the ':'
-	items := strings.Split(os.ExpandEnv(value), ":")
+	// step: split on the separator, default ':'
+	sep := getEnv("VAULT_SIDEKICK_SEPARATOR", ":")
+	items := strings.Split(os.ExpandEnv(value), sep)
 	if len(items) < 2 {
 		return fmt.Errorf("invalid resource, must have at least two sections TYPE:PATH")
 	}


### PR DESCRIPTION
Allows overriding separator in the `-cn` flag.

Use case: I've got to request certs with `:` in the common name.