### PR TITLE
utils: split exec args on space

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -202,7 +202,15 @@ func processResource(rn *VaultResource, data map[string]interface{}) (err error)
 	// step: check if we need to execute a command
 	if rn.execPath != "" {
 		glog.V(10).Infof("executing the command: %s for resource: %s", rn.execPath, filename)
-		cmd := exec.Command(rn.execPath, filename)
+		parts := strings.Split(rn.execPath, " ")
+		var args []string
+		if len(parts) > 1 {
+			args = parts[1:]
+		} else {
+			args = []string{filename}
+		}
+
+		cmd := exec.Command(parts[0], args...)
 		cmd.Start()
 		timer := time.AfterFunc(options.execTimeout, func() {
 			if err = cmd.Process.Kill(); err != nil {


### PR DESCRIPTION
this allows more advanced usage without having to call a script
directly, e.g. `pkill {myapp}`. if there is only a single cmd
passed, then fallback to the existing behavior of passing the
filename as an argument.