### PR TITLE
Add SSH resource type and template output format

### DIFF
--- a/formats.go
+++ b/formats.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
@@ -151,6 +152,19 @@ func writeJSONFile(filename string, data map[string]interface{}, mode os.FileMod
 	if err != nil {
 		return err
 	}
+
+	return writeFile(filename, content, mode)
+}
+
+func writeTemplateFile(filename string, data map[string]interface{}, mode os.FileMode, templateFile string) error {
+	tpl := template.Must(template.ParseFiles(templateFile))
+
+	var templateOutput bytes.Buffer
+	if err := tpl.Execute(&templateOutput, data); err != nil {
+		return err
+	}
+
+	content := []byte(fmt.Sprintf("%s", templateOutput.String()))
 
 	return writeFile(filename, content, mode)
 }

--- a/utils.go
+++ b/utils.go
@@ -191,6 +191,8 @@ func processResource(rn *VaultResource, data map[string]interface{}) (err error)
 		err = writeTxtFile(filename, data, rn.fileMode)
 	case "bundle":
 		err = writeCertificateBundleFile(filename, data, rn.fileMode)
+	case "template":
+		err = writeTemplateFile(filename, data, rn.fileMode, rn.templateFile)
 	default:
 		return fmt.Errorf("unknown output format: %s", rn.format)
 	}

--- a/vault.go
+++ b/vault.go
@@ -412,6 +412,21 @@ func (r VaultService) get(rn *watchedResource) error {
 				secret, err = r.client.Logical().Read(rn.resource.path)
 			}
 		}
+	case "ssh":
+		publicKeyData, err := ioutil.ReadFile(params["public_key_path"].(string))
+
+		if err != nil {
+			return fmt.Errorf("could not read data at specified public_key_path")
+		}
+
+		publicKeyDataString := string(publicKeyData)
+
+		sshParams := map[string]interface{}{
+			"public_key": publicKeyDataString,
+			"cert_type": params["cert_type"].(string),
+		}
+
+		secret, err = r.client.Logical().Write(fmt.Sprintf(rn.resource.path), sshParams)
 	}
 	// step: check the error if any
 	if err != nil {

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	resourceFormatRegex = regexp.MustCompile("^(yaml|yml|json|env|ini|txt|cert|bundle|csv)$")
+	resourceFormatRegex = regexp.MustCompile("^(yaml|yml|json|env|ini|txt|cert|bundle|csv|template)$")
 
 	// a map of valid resource to retrieve from vault
 	validResources = map[string]bool{
@@ -71,6 +71,7 @@ var (
 		"transit":   true,
 		"cubbyhole": true,
 		"cassandra": true,
+		"ssh": true,
 	}
 )
 
@@ -165,6 +166,13 @@ func (r *VaultResource) isValidResource() error {
 	case "tpl":
 		if _, found := r.options[optionTemplatePath]; !found {
 			return fmt.Errorf("template resource requires a template path option")
+		}
+	case "ssh":
+		if _, found := r.options["public_key_path"]; !found {
+			return fmt.Errorf("ssh resource requires a public key file path specified")
+		}
+		if _, found := r.options["cert_type"]; !found {
+			return fmt.Errorf("ssh resource requires cert_type to be either host or user")
 		}
 	}
 

--- a/vault_resource_test.go
+++ b/vault_resource_test.go
@@ -41,4 +41,6 @@ func TestIsValid(t *testing.T) {
 	assert.NotNil(t, resource.IsValid())
 	resource.resource = "pki"
 	assert.NotNil(t, resource.IsValid())
+	resource.resource = "ssh"
+	assert.NotNil(t, resource.IsValid())
 }


### PR DESCRIPTION
This adds basic support for the SSH secrets backend in Vault, as well as a Template Output format to allow for creating files based on a Go template. I saw some `templateFile` references in the codebase but couldn't tell if this was part of a feature I'm not aware of or whether it's incomplete?

Would be nice to get some feedback on this PR first before I go about adding some tests and updating the documentation.

Example usage with SSH Host Key signing:

Prerequisite: Follow guide at https://www.vaultproject.io/api/secret/ssh/index.html

```
./vault-sidekick -alsologtostderr -output ./output -cn=ssh:ssh-host-signer/sign/hostrole:public_key_path=/etc/ssh/ssh_host_rsa_key.pub,cert_type=host,fmt=template,tpl=signed_key.tpl
```

`signed_key.tpl`:

```
{{ .signed_key }}
```

Expected output:
```
ssh-rsa-cert-v01@openssh.com XXXXXXXX
```