### PR TITLE
Support secrets from v2 kv store

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ spec:
       - -cn=pki:project1/certs/example.com:common_name=commons.example.com,revoke=true,update=2h
       - -cn=secret:secret/db/prod/username:file=.credentials
       - -cn=secret:secret/db/prod/password:retries=true
+      - -cn=secret:scecret/data/db/dev/username:file=.kv2credentials
       - -cn=aws:aws/creds/s3_backup_policy:file=.s3_creds
     volumeMounts:
       - name: secrets
@@ -85,6 +86,7 @@ The above equates to:
 - Write all the secrets to the /etc/secrets directory
 - Retrieve a dynamic certificate pair for me, with the common name: 'commons.example.com' and renew the cert when it expires automatically
 - Retrieve the two static secrets /db/prod/{username,password} and write them to .credentials and password.secret respectively
+- Retrieve the latest version of static secret /db/dev/username from a v2 kv store and write it to .kv2credentials
 - Apply the IAM policy, renew the policy when required and file the API tokens to .s3_creds in the /etc/secrets directory
 - Read the template at /etc/templates/db.tmpl, produce the content from Vault and write to /etc/credentials file
 

--- a/vault.go
+++ b/vault.go
@@ -414,6 +414,10 @@ func (r VaultService) get(rn *watchedResource) error {
 				secret, err = r.client.Logical().Read(rn.resource.path)
 			}
 		}
+		// if there is a top-level metadata key this is from a v2 kv store
+		if _, ok := secret.Data["metadata"]; ok {
+			secret.Data = secret.Data["data"].(map[string]interface{})
+		}
 	case "ssh":
 		publicKeyData, err := ioutil.ReadFile(params["public_key_path"].(string))
 


### PR DESCRIPTION
The v2 kv secrets engine returns the secret data in a different format (https://www.vaultproject.io/api/secret/kv/kv-v2.html#sample-response-1) than v1, this means that vault-sidekick writes a string representation of a map with "data" and "metadata" keys to file, rather than the secret data.

This change introduces a check to identify if the secrets engine is a v1 or v2 response.