### PR TITLE
add support to the database backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### **Version v0.3.9**
+
+* Added support for the database backend [#PR85](https://github.com/UKHomeOffice/vault-sidekick/pull/85)
 
 #### **Version v0.3.8**
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The format is;
 -cn=RESOURCE_TYPE:PATH:OPTIONS
 ```
 
-The sidekick supports the following resource types: mysql, postgres, pki, aws, gcp, secret, cubbyhole, raw, cassandra and transit
+The sidekick supports the following resource types: mysql, postgres, database, pki, aws, gcp, secret, cubbyhole, raw, cassandra and transit
 
 ## Environment Variable Expansion
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	prog    = "vault-sidekick"
-	release = "v0.3.8"
+	release = "v0.3.9"
 	gitsha  = ""
 )
 

--- a/vault.go
+++ b/vault.go
@@ -401,6 +401,8 @@ func (r VaultService) get(rn *watchedResource) error {
 		fallthrough
 	case "postgres":
 		fallthrough
+	case "database":
+		fallthrough
 	case "secret":
 		secret, err = r.client.Logical().Read(rn.resource.path)
 		// We must generate the secret if we have the create flag

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -73,6 +73,7 @@ var (
 		"cubbyhole": true,
 		"cassandra": true,
 		"ssh":       true,
+		"database":  true,
 	}
 )
 


### PR DESCRIPTION
The postgresql and mysql database backend are deprecated and the prefer way is to use the database backend.
All that is needed is to add the `database` key to the authorized resources to support it.