### PR TITLE
fix lease duration of one second

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -134,7 +134,11 @@ func readYAMLFile(filename string) (*vaultAuthOptions, error) {
 //	min			: the smallest number we can accept
 //	max			: the largest number we can accept
 func getDurationWithin(min, max int) time.Duration {
-	duration := rand.Intn(max-min) + min
+	jitter := max-min
+	if (jitter <= 0) {
+		jitter = 1
+	}
+	duration := rand.Intn(jitter) + min
 	return time.Duration(duration) * time.Second
 }
 

--- a/utils.go
+++ b/utils.go
@@ -134,8 +134,8 @@ func readYAMLFile(filename string) (*vaultAuthOptions, error) {
 //	min			: the smallest number we can accept
 //	max			: the largest number we can accept
 func getDurationWithin(min, max int) time.Duration {
-	jitter := max-min
-	if (jitter <= 0) {
+	jitter := max - min
+	if jitter <= 0 {
 		jitter = 1
 	}
 	duration := rand.Intn(jitter) + min

--- a/utils_test.go
+++ b/utils_test.go
@@ -113,3 +113,11 @@ func TestReadConfigTokenYAML(t *testing.T) {
 		t.Errorf("Expected token %s got %s", expected, o.Token)
 	}
 }
+
+func TestGetDurationWithin(t *testing.T) {
+	duration := getDurationWithin(1, 1)
+
+	if duration <= 0 {
+		t.Errorf("Expected duration to be higher than 0 got %d", duration)
+	}
+}


### PR DESCRIPTION
If the lease duration is one second `rand.Intn` will fail because it does not allow values which are <= 0
