### PR TITLE
Support custom login path for approle auth backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ The Kubernetes auth plugin supports the following environment variables:
 - `VAULT_K8S_LOGIN_PATH` - If your Kubernetes auth backend is mounted at a path other than `kubernetes/` you will need to set this. Default `/v1/auth/kubernetes/login`
 - `VAULT_K8S_TOKEN_PATH` - If you mount in-pod service account tokens to a non-default path, you will need to set this. Default `/var/run/secrets/kubernetes.io/serviceaccount/token`
 
+### AppRole Authentication
+
+The AppRole auth plugin supports the following configurations / environment variables:
+
+- `role_id` / `VAULT_SIDEKICK_ROLE_ID` - The approle role_id to authenticate with (**REQUIRED**)
+- `secret_id` / `VAULT_SIDEKICK_SECRET_ID` - The approle secret_id to authenticate with (**REQUIRED**)
+- `login_path` / `VAULT_APPROLE_LOGIN_PATH` - If your AppRole auth backend is mounted at a path other than `approle/` you will need to set this. Default `/v1/auth/approle/login`
+
 ## Secret Renewals
 
 The default behaviour of vault-sidekick is **not** to renew a lease, but to retrieve a new secret and allow the previous to

--- a/auth_approle.go
+++ b/auth_approle.go
@@ -28,8 +28,8 @@ type authAppRolePlugin struct {
 }
 
 type appRoleLogin struct {
-	RoleID   string `json:"role_id,omitempty"`
-	SecretID string `json:"secret_id,omitempty"`
+	RoleID    string `json:"role_id,omitempty"`
+	SecretID  string `json:"secret_id,omitempty"`
 	LoginPath string `json:"login_path,omitempty"`
 }
 

--- a/auth_approle.go
+++ b/auth_approle.go
@@ -30,6 +30,7 @@ type authAppRolePlugin struct {
 type appRoleLogin struct {
 	RoleID   string `json:"role_id,omitempty"`
 	SecretID string `json:"secret_id,omitempty"`
+	LoginPath string `json:"login_path,omitempty"`
 }
 
 // NewAppRolePlugin creates a new App Role plugin
@@ -47,9 +48,12 @@ func (r authAppRolePlugin) Create(cfg *vaultAuthOptions) (string, error) {
 	if cfg.SecretID == "" {
 		cfg.SecretID = os.Getenv("VAULT_SIDEKICK_SECRET_ID")
 	}
+	if cfg.LoginPath == "" {
+		cfg.LoginPath = getEnv("VAULT_APPROLE_LOGIN_PATH", "/v1/auth/approle/login")
+	}
 
 	// step: create the token request
-	request := r.client.NewRequest("POST", "/v1/auth/approle/login")
+	request := r.client.NewRequest("POST", cfg.LoginPath)
 	login := appRoleLogin{SecretID: cfg.SecretID, RoleID: cfg.RoleID}
 	if err := request.SetJSONBody(login); err != nil {
 		return "", err

--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ type vaultAuthOptions struct {
 	VaultURL      string `json:"vaultAddr"`
 	RoleID        string `json:"role_id" yaml:"role_id"`
 	SecretID      string `json:"secret_id" yaml:"secret_id"`
+	LoginPath     string `json:"login_path" yaml:"login_path"`
 	FileName      string
 	FileFormat    string
 	Username      string

--- a/tests/approle_auth_file.json
+++ b/tests/approle_auth_file.json
@@ -1,1 +1,1 @@
-{"method": "approle", "role_id": "admin", "secret_id": "foobar"}
+{"method": "approle", "role_id": "admin", "secret_id": "foobar", "login_path": "/v1/auth/approle/login"}

--- a/tests/approle_auth_file.yml
+++ b/tests/approle_auth_file.yml
@@ -1,3 +1,4 @@
 method: approle
 role_id: admin
 secret_id: foobar
+login_path: /v1/auth/approle/login


### PR DESCRIPTION
Allow setting a custom vault login path for approle backend 

Defaults to standard `/v1/auth/approle/login`

Add README section with described configuration / environment variables 