### PR TITLE
Create ca_chain file when using fmt=cert

### DIFF
--- a/formats.go
+++ b/formats.go
@@ -71,9 +71,9 @@ func writeCAChain(filename string, data map[string]interface{}, mode os.FileMode
 	const element = "ca_chain"
 	const suffix = "ca"
 
-	// assume this is always a slice so cast the entry to []interface
-	chain, found := data[element].([]interface{})
-	if !found {
+	// the chain should be a slice so assert that the type is []interface
+	chain, ok := data[element].([]interface{})
+	if !ok {
 		glog.Errorf("didn't find the certification option: %s", element)
 	}
 
@@ -89,7 +89,7 @@ func writeCAChain(filename string, data map[string]interface{}, mode os.FileMode
 	}
 
 	if err := writeFile(name, []byte(fmt.Sprintf("%s", certChain)), mode); err != nil {
-		glog.Errorf("failed to write resource: %s, element: %s, filename: %s, error: %s", filename, suffix, name, err)
+		return fmt.Errorf("failed to write resource: %s, element: %s, filename: %s, error: %s", filename, suffix, name, err)
 	}
 
 	return nil
@@ -98,6 +98,7 @@ func writeCertificateFile(filename string, data map[string]interface{}, mode os.
 	if err := writeCAChain(filename, data, mode); err != nil {
 		glog.Errorf("failed to write CA chain: %s", err)
 	}
+
 	files := map[string]string{
 		"certificate": "crt",
 		"issuing_ca":  "ca",

--- a/formats.go
+++ b/formats.go
@@ -75,6 +75,7 @@ func writeCAChain(filename string, data map[string]interface{}, mode os.FileMode
 	chain, ok := data[element].([]interface{})
 	if !ok {
 		glog.Errorf("didn't find the certification option: %s", element)
+		return nil
 	}
 
 	name := fmt.Sprintf("%s.%s.%s", filename, element, suffix)

--- a/formats.go
+++ b/formats.go
@@ -67,7 +67,35 @@ func writeEnvFile(filename string, data map[string]interface{}, mode os.FileMode
 	return writeFile(filename, buf.Bytes(), mode)
 }
 
+func writeCAChain(filename string, data map[string]interface{}, mode os.FileMode) error {
+	const element = "ca_chain"
+	const suffix = "ca"
+
+	// assume this is always a slice so cast the entry to []interface
+	chain, found := data[element].([]interface{})
+	if !found {
+		glog.Errorf("didn't find the certification option: %s", element)
+	}
+
+	name := fmt.Sprintf("%s.%s.%s", filename, element, suffix)
+
+	certChain := ""
+	for count, cert := range chain {
+		certChain += fmt.Sprintf("%s", cert)
+		// append a newline after each cert except last
+		if count < len(chain)-1 {
+			certChain += "\n"
+		}
+	}
+
+	if err := writeFile(name, []byte(fmt.Sprintf("%s", certChain)), mode); err != nil {
+		glog.Errorf("failed to write resource: %s, element: %s, filename: %s, error: %s", filename, suffix, name, err)
+	}
+
+	return nil
+}
 func writeCertificateFile(filename string, data map[string]interface{}, mode os.FileMode) error {
+	writeCAChain(filename, data, mode)
 	files := map[string]string{
 		"certificate": "crt",
 		"issuing_ca":  "ca",

--- a/formats.go
+++ b/formats.go
@@ -95,7 +95,9 @@ func writeCAChain(filename string, data map[string]interface{}, mode os.FileMode
 	return nil
 }
 func writeCertificateFile(filename string, data map[string]interface{}, mode os.FileMode) error {
-	writeCAChain(filename, data, mode)
+	if err := writeCAChain(filename, data, mode); err != nil {
+		glog.Errorf("failed to write CA chain: %s", err)
+	}
 	files := map[string]string{
 		"certificate": "crt",
 		"issuing_ca":  "ca",


### PR DESCRIPTION
A first stab at fixing: - https://github.com/UKHomeOffice/vault-sidekick/issues/91

**Some questions about this solution**
* Should the ability to pull out the whole chain be optional?
* Should this be implemented as a new fmt or an additional flag or just done by default?
* Is it acceptable to write out the whole chain into a single file?
* What should the filename(s) be? currently I am appending .ca_chain.ca

**Other notes**
* I added a newline char between the certs when writing them to a single file. Should I use a localised/os specific carriage return?
* The code assumes that ca_cert is always an interface slice, the only other way I could think of was using reflection, but this is usually frowned upon. I looked at the vault code and it seems like this should always be a slice.
