### PR TITLE
Fix lease expiration checks to prevent permenently revoked resources after temporary `vault` issue

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -322,10 +322,11 @@ func (r VaultService) renew(rn *watchedResource) error {
 
 	// step: update the resource
 	rn.lastUpdated = time.Now()
-	rn.leaseExpireTime = rn.lastUpdated.Add(time.Duration(secret.LeaseDuration))
+	leaseDuration := time.Duration(secret.LeaseDuration) * time.Second
+	rn.leaseExpireTime = rn.lastUpdated.Add(leaseDuration)
 
 	glog.V(3).Infof("renewed resource: %s, leaseId: %s, leaseDuration: %s, expiration: %s",
-		rn.resource, rn.secret.LeaseID, time.Duration(rn.secret.LeaseDuration)*time.Second, rn.leaseExpireTime)
+		rn.resource, rn.secret.LeaseID, leaseDuration, rn.leaseExpireTime)
 
 	return nil
 }
@@ -457,10 +458,11 @@ func (r VaultService) get(rn *watchedResource) error {
 	// step: update the watched resource
 	rn.lastUpdated = time.Now()
 	rn.secret = secret
-	rn.leaseExpireTime = rn.lastUpdated.Add(time.Duration(secret.LeaseDuration))
+	leaseDuration := time.Duration(rn.secret.LeaseDuration) * time.Second
+	rn.leaseExpireTime = rn.lastUpdated.Add(leaseDuration)
 
-	glog.V(3).Infof("retrieved resource: %s, leaseId: %s, leaseDuration: %s",
-		rn.resource, rn.secret.LeaseID, time.Duration(rn.secret.LeaseDuration)*time.Second)
+	glog.V(3).Infof("retrieved resource: %s, leaseId: %s, leaseDuration: %s, expiration: %s",
+		rn.resource, rn.secret.LeaseID, leaseDuration, rn.leaseExpireTime)
 
 	return err
 }

--- a/vault.go
+++ b/vault.go
@@ -324,8 +324,8 @@ func (r VaultService) renew(rn *watchedResource) error {
 	rn.lastUpdated = time.Now()
 	rn.leaseExpireTime = rn.lastUpdated.Add(time.Duration(secret.LeaseDuration))
 
-	glog.V(3).Infof("renewed resource: %s, leaseId: %s, lease_time: %s, expiration: %s",
-		rn.resource, rn.secret.LeaseID, rn.secret.LeaseID, rn.leaseExpireTime)
+	glog.V(3).Infof("renewed resource: %s, leaseId: %s, leaseDuration: %s, expiration: %s",
+		rn.resource, rn.secret.LeaseID, time.Duration(rn.secret.LeaseDuration)*time.Second, rn.leaseExpireTime)
 
 	return nil
 }
@@ -459,7 +459,7 @@ func (r VaultService) get(rn *watchedResource) error {
 	rn.secret = secret
 	rn.leaseExpireTime = rn.lastUpdated.Add(time.Duration(secret.LeaseDuration))
 
-	glog.V(3).Infof("retrieved resource: %s, leaseId: %s, lease_time: %s",
+	glog.V(3).Infof("retrieved resource: %s, leaseId: %s, leaseDuration: %s",
 		rn.resource, rn.secret.LeaseID, time.Duration(rn.secret.LeaseDuration)*time.Second)
 
 	return err

--- a/vault.go
+++ b/vault.go
@@ -202,7 +202,7 @@ func (r *VaultService) vaultServiceProcessor() {
 					x.secret.LeaseID, x.resource.renewable, x.resource.revoked)
 
 				// step: we need to check if the lease has expired?
-				if time.Now().Before(x.leaseExpireTime) {
+				if time.Now().After(x.leaseExpireTime) {
 					glog.V(3).Infof("the lease on resource: %s has expired, we need to get a new lease", x.resource)
 					// push into the retrieval channel and break
 					r.scheduleNow(x, retrieveChannel)


### PR DESCRIPTION
Currently, `time.Duration(secret.LeaseDuration)` is added to the current time to determine `leaseExpireTime`.  This is erroneous because `secret.LeaseDuration` is in seconds and `time.Duration` stores nanoseconds.  This causes `leaseExpireTime` to be effectively set to ~`time.Now()`.

Due to the above bug, `time.Now()` is always after `leaseExpireTime`, but the code also has a bug reversing the meaning of the lease expiration check so the lease-expired codepath is never taken.  This means that if a lease ever does expire (which we've seen when there are `vault` connectivity issues that last longer than the 5-20% cushion in the lease-renewal time) then `vault-sidekick` erroneously attempts to renew it forever even though it should really re-retrieve the resource.

Multiply the duration by `time.Second` to get the right units to fix `leaseExpireTime` and fix the lease expiration check to work properly.  Together these mean that temporary `vault` issues don't result in permanently-expired/revoked `vault-sidekick` resources.

These fixes remove the need for / closes #89 