### PR TITLE
Ttl config

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,4 @@ bundle format is very similar in the sense it similar takes the private key and 
 - **exec** (execute) execute's a command when resource is updated or changed
 - **retries**: (retries) the maximum number of times to retry retrieving a resource. If not set, resources will be retried indefinitely
 - **jitter**: (jitter) an optional maximum jitter duration. If specified, a random duration between 0 and `jitter` will be subtracted from the renewal time for the resource
+- **ttl**: (ttl) an optional ttl to use with the Vault PKI backend, should be specified as per the Vault PKI backend ttl resource (eg. 24h for one day). Hours are the largest suffix.

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -52,7 +52,7 @@ const (
 	// to updates for this resource. If non-zero, a random value between 0 and
 	// maxJitter will be subtracted from the update period.
 	optionMaxJitter = "jitter"
-        // optionTtl specifies requested Time To Live for use with the PKI Backend
+	// optionTtl specifies requested Time To Live for use with the PKI Backend
 	optionTtl = "ttl"
 	// defaultSize sets the default size of a generic secret
 	defaultSize = 20
@@ -130,7 +130,7 @@ type VaultResource struct {
 	// performing renewals
 	maxJitter time.Duration
 	// specifies requested Time To Live for use with the PKI Backend
-        ttl string
+	ttl string
 }
 
 // GetFilename generates a resource filename by default the resource name and resource type, which

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -52,6 +52,8 @@ const (
 	// to updates for this resource. If non-zero, a random value between 0 and
 	// maxJitter will be subtracted from the update period.
 	optionMaxJitter = "jitter"
+        // optionTtl specifies requested Time To Live for use with the PKI Backend
+	optionTtl = "ttl"
 	// defaultSize sets the default size of a generic secret
 	defaultSize = 20
 )
@@ -127,6 +129,8 @@ type VaultResource struct {
 	// maxJitter is the maximum jitter duration to use for this resource when
 	// performing renewals
 	maxJitter time.Duration
+	// specifies requested Time To Live for use with the PKI Backend
+        ttl string
 }
 
 // GetFilename generates a resource filename by default the resource name and resource type, which

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -144,6 +144,8 @@ func (r *VaultResources) Set(value string) error {
 					return fmt.Errorf("the jitter option: %s is invalid, should be in duration format", value)
 				}
 				rn.maxJitter = maxJitter
+			case optionTtl:
+				rn.ttl = value
 			default:
 				rn.options[name] = value
 			}


### PR DESCRIPTION
Allow ttl to be passed as a parameter for use with the Vault PKI backend.