### PR TITLE
Add client auth

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,6 +53,10 @@ type config struct {
 	vaultRenewToken bool
 	// the vault ca file
 	vaultCaFile string
+	// the client certificate
+	vaultClientCertificate string
+	// the client private key
+	vaultClientPrivateKey string
 	// the place to write the resources
 	outputDir string
 	// switch on dry run
@@ -91,6 +95,8 @@ func init() {
 	flag.BoolVar(&options.dryRun, "dryrun", false, "perform a dry run, printing the content to screen")
 	flag.BoolVar(&options.skipTLSVerify, "tls-skip-verify", false, "whether to check and verify the vault service certificate")
 	flag.StringVar(&options.vaultCaFile, "ca-cert", "", "the path to the file container the CA used to verify the vault service")
+	flag.StringVar(&options.vaultClientCertificate, "client-cert", "", "the path to the file container that vault will use to verify the client")
+	flag.StringVar(&options.vaultClientPrivateKey, "client-key", "", "the path to the file container that vault will use to identify the client")
 	flag.DurationVar(&options.statsInterval, "stats", time.Duration(1)*time.Hour, "the interval to produce statistics on the accessed resources")
 	flag.DurationVar(&options.execTimeout, "exec-timeout", time.Duration(60)*time.Second, "the timeout applied to commands on the exec option")
 	flag.BoolVar(&options.showVersion, "version", false, "show the vault-sidekick version")
@@ -139,6 +145,26 @@ func validateOptions(cfg *config) (err error) {
 		if exists, _ := fileExists(cfg.vaultCaFile); !exists {
 			return fmt.Errorf("the ca certificate file: %s does not exist", cfg.vaultCaFile)
 		}
+	}
+
+	if cfg.vaultClientCertificate != "" {
+		if exists, _ := fileExists(cfg.vaultClientCertificate); !exists {
+			return fmt.Errorf("the client certificate file: %s does not exist", cfg.vaultClientCertificate)
+		}
+	}
+
+	if cfg.vaultClientPrivateKey != "" {
+		if exists, _ := fileExists(cfg.vaultClientPrivateKey); !exists {
+			return fmt.Errorf("the client private key file: %s does not exist", cfg.vaultClientPrivateKey)
+		}
+	}
+
+	if cfg.vaultClientPrivateKey != "" && cfg.vaultClientCertificate == "" {
+		return fmt.Errorf("you are supplying the client private key, but not the certificate")
+	}
+
+	if cfg.vaultClientPrivateKey == "" && cfg.vaultClientCertificate != "" {
+		return fmt.Errorf("you are supplying the client certificate, but not the private key")
 	}
 
 	if cfg.skipTLSVerify == true && cfg.vaultCaFile != "" {

--- a/config.go
+++ b/config.go
@@ -53,9 +53,9 @@ type config struct {
 	vaultRenewToken bool
 	// the vault ca file
 	vaultCaFile string
-	// the client certificate
+	// the client certificate file
 	vaultClientCertificate string
-	// the client private key
+	// the client private key file
 	vaultClientPrivateKey string
 	// the place to write the resources
 	outputDir string

--- a/vault.go
+++ b/vault.go
@@ -576,11 +576,13 @@ func buildHTTPTransport(opts *config) (*http.Transport, error) {
 	}
 
 	// step: are we using client authentication
-	cert, err := tls.LoadX509KeyPair("vault-client.crt", "vault-client.key")
-	if err != nil {
-		return nil, fmt.Errorf("unable to read in the ca: %s, reason: %s", opts.vaultCaFile, err)
+	if opts.vaultClientCertificate != "" && opts.vaultClientPrivateKey != "" {
+		cert, err := tls.LoadX509KeyPair(opts.vaultClientCertificate, opts.vaultClientPrivateKey)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read the client keypair, reason: %s", err)
+		}
+		transport.TLSClientConfig.Certificates = []tls.Certificate{cert}
 	}
-	transport.TLSClientConfig.Certificates = []tls.Certificate{cert}
 
 	// step: are we loading a CA file
 	if opts.vaultCaFile != "" {


### PR DESCRIPTION
Add CLI flags to supply client-side authorisation files. 

Example behavior:

`vault-sidekick` can't access vault without client authorisation

```
$ export VAULT_ADDR=https://${vault_addr}:${vault_port}
$ export VAULT_AUTH_METHOD=kubernetes
$ export VAULT_SIDEKICK_ROLE=example
$
$ bin/vault-sidekick

[error] unable to create the vault client: Post https://${vault_addr}:${vault_port}/v1/auth/kubernetes/login: remote error: tls: bad certificate
```

Supplying the key + cert, we can now talk to vault (hitting an expected error)

```
$ bin/vault-sidekick \
    -client-cert vault-client.crt \
    -client-key vault-client.key

[error] unable to create the vault client: Error making API request.

URL: POST https://${vault_addr}:${vault_port}/v1/auth/kubernetes/login
Code: 400. Errors:

* missing client token
```

Error if you try to supply only the key or cert

```
$ bin/vault-sidekick \
    -client-cert vault-client.crt

[error] invalid options, you are supplying the client certificate, but not the private key
```