### PR TITLE
Add ability to append to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Vault Sidekick is a add-on container which can be used as a generic entry-point 
 ## Usage
 
 ```shell
-$ sudo docker run --rm quay.io/ukhomeofficedigital/vault-sidekick:v0.3.3 -help
+$ sudo docker run --rm quay.io/ukhomeofficedigital/vault-sidekick:v0.3.14 -help
 Usage of /vault-sidekick:
   -alsologtostderr
     	log to standard error as well as files
@@ -68,7 +68,7 @@ The below is taken from a [Kubernetes](https://github.com/kubernetes/kubernetes)
 spec:
   containers:
   - name: vault-side-kick
-    image: quay.io/ukhomeofficedigital/vault-sidekick:v0.3.3
+    image: quay.io/ukhomeofficedigital/vault-sidekick:v0.3.14
     args:
       - -output=/etc/secrets
       - -cn=pki:project1/certs/example.com:common_name=commons.example.com,revoke=true,update=2h
@@ -180,6 +180,7 @@ bundle format is very similar in the sense it similar takes the private key and 
 - **file**: (filaname) by default all file are relative to the output directory specified and will have the name NAME.RESOURCE; the fn options allows you to switch names and paths to write the files
 - **mode**: (mode) overrides the default file permissions of the secret from 0664
 - **create**: (create) create the resource
+- **append**: (appends) appends secrets to the resource. 
 - **update**: (update) override the lease time of this resource and get/renew a secret on the specified duration e.g 1m, 2d, 5m10s
 - **renew**: (renewal) override the default behavour on this resource, renew the resource when coming close to expiration e.g true, TRUE
 - **delay**: (renewal-delay) delay the revoking the lease of a resource for x period once time e.g 1m, 1h20s

--- a/utils.go
+++ b/utils.go
@@ -180,27 +180,27 @@ func processResource(rn *VaultResource, data map[string]interface{}) (err error)
 	case "yaml":
 		fallthrough
 	case "yml":
-		err = writeYAMLFile(filename, data, rn.fileMode)
+		err = writeYAMLFile(filename, data, rn.fileMode, rn.append)
 	case "json":
-		err = writeJSONFile(filename, data, rn.fileMode)
+		err = writeJSONFile(filename, data, rn.fileMode, rn.append)
 	case "ini":
-		err = writeIniFile(filename, data, rn.fileMode)
+		err = writeIniFile(filename, data, rn.fileMode, rn.append)
 	case "csv":
-		err = writeCSVFile(filename, data, rn.fileMode)
+		err = writeCSVFile(filename, data, rn.fileMode, rn.append)
 	case "env":
-		err = writeEnvFile(filename, data, rn.fileMode)
+		err = writeEnvFile(filename, data, rn.fileMode, rn.append)
 	case "cert":
-		err = writeCertificateFile(filename, data, rn.fileMode)
+		err = writeCertificateFile(filename, data, rn.fileMode, rn.append)
 	case "txt":
-		err = writeTxtFile(filename, data, rn.fileMode)
+		err = writeTxtFile(filename, data, rn.fileMode, rn.append)
 	case "bundle":
-		err = writeCertificateBundleFile(filename, data, rn.fileMode)
+		err = writeCertificateBundleFile(filename, data, rn.fileMode, rn.append)
 	case "credential":
-		err = writeCredentialFile(filename, data, rn.fileMode)
+		err = writeCredentialFile(filename, data, rn.fileMode, rn.append)
 	case "template":
-		err = writeTemplateFile(filename, data, rn.fileMode, rn.templateFile)
+		err = writeTemplateFile(filename, data, rn.fileMode, rn.templateFile, rn.append)
 	case "aws":
-		err = writeAwsCredentialFile(filename, data, rn.fileMode)
+		err = writeAwsCredentialFile(filename, data, rn.fileMode, rn.append)
 	default:
 		return fmt.Errorf("unknown output format: %s", rn.format)
 	}

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -42,6 +42,8 @@ const (
 	optionExec = "exec"
 	// optionCreate creates a secret if it doesn't exist
 	optionCreate = "create"
+	// optionAppend appends to the secret if it already exists
+	optionAppend = "append"
 	// optionSize sets the initial size of a password secret
 	optionSize = "size"
 	// optionsMode is the file permissions on the secret
@@ -86,6 +88,7 @@ func defaultVaultResource() *VaultResource {
 		options:   make(map[string]string, 0),
 		renewable: false,
 		revoked:   false,
+		append:    false,
 		size:      defaultSize,
 	}
 }
@@ -108,6 +111,8 @@ type VaultResource struct {
 	update time.Duration
 	// whether the resource should be created?
 	create bool
+	// whether the resource should be appended to?
+	append bool
 	// the size of a secret to create
 	size int64
 	// the filename to save the secret

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -120,6 +120,15 @@ func (r *VaultResources) Set(value string) error {
 					return fmt.Errorf("the create option is only supported for 'cn=secret' at this time")
 				}
 				rn.create = choice
+			case optionAppend:
+				choice, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("the create option: %s is invalid, should be a boolean", value)
+				}
+				if rn.resource != "secret" {
+					return fmt.Errorf("the create option is only supported for 'cn=secret' at this time")
+				}
+				rn.append = choice
 			case optionSize:
 				size, err := strconv.ParseInt(value, 10, 16)
 				if err != nil {

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -123,10 +123,10 @@ func (r *VaultResources) Set(value string) error {
 			case optionAppend:
 				choice, err := strconv.ParseBool(value)
 				if err != nil {
-					return fmt.Errorf("the create option: %s is invalid, should be a boolean", value)
+					return fmt.Errorf("the append option: %s is invalid, should be a boolean", value)
 				}
 				if rn.resource != "secret" {
-					return fmt.Errorf("the create option is only supported for 'cn=secret' at this time")
+					return fmt.Errorf("the append option is only supported for 'cn=secret' at this time")
 				}
 				rn.append = choice
 			case optionSize:

--- a/vault_resources_test.go
+++ b/vault_resources_test.go
@@ -35,12 +35,14 @@ func TestSetResources(t *testing.T) {
 	assert.Nil(t, items.Set("pki:example-dot-com:common_name=blah.example.com,file=/etc/certs/ssl/blah.example.com"))
 	assert.Nil(t, items.Set("pki:example-dot-com:common_name=blah.example.com,renew=true"))
 	assert.Nil(t, items.Set("secret:secrets/${ENV}/me:file=filename.test,fmt=yaml"))
+	assert.Nil(t, items.Set("secret:secrets/${ENV}/me:file=filename.test,fmt=yaml,append=true"))
 
 	assert.NotNil(t, items.Set("secret:"))
 	assert.NotNil(t, items.Set("secret:test:file=filename.test,fmt="))
 	assert.NotNil(t, items.Set("secret::file=filename.test,fmt=yaml"))
 	assert.NotNil(t, items.Set("secret:te1st:file=filename.test,fmt="))
 	assert.NotNil(t, items.Set("file=filename.test,fmt=yaml"))
+	assert.NotNil(t, items.Set("secret:secrets/${ENV}/me:file=filename.test,fmt=yaml,append=wat"))
 }
 
 func TestSetEnvironmentResource(t *testing.T) {


### PR DESCRIPTION
We have the use-case where we would like to get environment variables
from multiple sources, but our apps expect to load a single `.env`
file. In order to remedy that, I added an append flag, which is by
default set to false.

This option is probably only really useful if one is using `one-shot`
(which we're using), otherwise the results might be unexpected.

If required, I can add more tests to this PR if this patch would be
interesting for you.

