### PR TITLE
Don't (re)try to renew revoked tokens or resources (and fix crash)

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -418,7 +418,7 @@ func (r VaultService) get(rn *watchedResource) error {
 			}
 		}
 		// if there is a top-level metadata key this is from a v2 kv store
-		if err == nil {
+		if err == nil && secret != nil {
 			if _, ok := secret.Data["metadata"]; ok {
 				secret.Data = secret.Data["data"].(map[string]interface{})
 			}


### PR DESCRIPTION
If a token (or its lease) is revoked its attempts to renew itself will fail with a `403: permission denied`.  Treat that case as a fatal errors since any credentials it's generated will have been revoked and it is unable to retrieve replacements.

If a resource (or its lease) is revoked its attempts to renew itself will fail with a `400: lease not found`.  Attempt to retrieve a new copy of the resource.


Also don't crash if secret can't be fetched:
If the secret wasn't found, `secret` and `err` would both be `nil` and `secret` would be dereferenced when checking to see if it was a v2 kv store causing a crash.