### PR TITLE
Move to latest alpine version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.12
 MAINTAINER Rohith <gambol99@gmail.com>
 
 RUN apk update && \

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	prog    = "vault-sidekick"
-	release = "v0.3.15"
+	release = "v0.3.16"
 	gitsha  = ""
 )
 


### PR DESCRIPTION
Alpine v3.5 ended support 2018-11-01 - this PR moves to Alpine v3.12 

Also bumped vault-sidekick version to v0.3.16